### PR TITLE
adbeta credentials

### DIFF
--- a/modules/dasBidAdapter.js
+++ b/modules/dasBidAdapter.js
@@ -335,6 +335,9 @@ export const spec = {
     const baseUrl = getEndpoint(data.ext.network);
     const fullUrl = `${baseUrl}?data=${encodeURIComponent(jsonData)}`;
 
+    // adbeta needs credentials omitted to avoid CORS issues, especially in Firefox
+    const useCredentials = !(!!data.ext?.adbeta);
+
     // Switch to POST if URL exceeds 8k characters
     if (fullUrl.length > 8192) {
       return {
@@ -342,7 +345,7 @@ export const spec = {
         url: baseUrl,
         data: jsonData,
         options: {
-          withCredentials: true,
+          withCredentials: useCredentials,
           crossOrigin: true,
           customHeaders: {
             'Content-Type': 'text/plain'
@@ -355,7 +358,7 @@ export const spec = {
       method: 'GET',
       url: fullUrl,
       options: {
-        withCredentials: true,
+        withCredentials: useCredentials,
         crossOrigin: true,
       },
     };

--- a/test/spec/modules/dasBidAdapter_spec.js
+++ b/test/spec/modules/dasBidAdapter_spec.js
@@ -265,6 +265,35 @@ describe('dasBidAdapter', function () {
       expect(payload.ext.network).to.equal('network1');
     });
 
+    it('should set withCredentials to false when adbeta flag is present', function () {
+      const bidRequestsWithAdbeta = [{
+        bidId: 'bid123',
+        params: {
+          site: 'site1',
+          area: 'area1',
+          slot: 'slot1',
+          network: 'network1',
+          adbeta: 'l1021885!slot.nativestd',
+          pageContext: {}
+        },
+        mediaTypes: {
+          banner: {
+            sizes: [[300, 250]]
+          }
+        }
+      }];
+
+      const bidderRequestWithAdbeta = {
+        bidderRequestId: 'reqId123',
+        ortb2: {},
+        adbeta: true
+      };
+
+      const request = spec.buildRequests(bidRequestsWithAdbeta, bidderRequestWithAdbeta);
+
+      expect(request.options.withCredentials).to.be.false;
+    });
+
     describe('interpretResponse', function () {
       const serverResponse = {
         body: {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
