### PR TITLE
DAS Adapter: simplify redundant boolean cast

### DIFF
--- a/modules/dasBidAdapter.js
+++ b/modules/dasBidAdapter.js
@@ -336,7 +336,7 @@ export const spec = {
     const fullUrl = `${baseUrl}?data=${encodeURIComponent(jsonData)}`;
 
     // adbeta needs credentials omitted to avoid CORS issues, especially in Firefox
-    const useCredentials = !(!!data.ext?.adbeta);
+    const useCredentials = !data.ext?.adbeta;
 
     // Switch to POST if URL exceeds 8k characters
     if (fullUrl.length > 8192) {


### PR DESCRIPTION
## Summary
- Simplify `!(!!data.ext?.adbeta)` to `!data.ext?.adbeta`
- Both expressions are functionally identical
- The simpler form passes ESLint `no-extra-boolean-cast` rule

## Test plan
- [x] Verified expressions are equivalent (see proof below)
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)