### PR TITLE
dasBidAdapter: add server-driven adserverTargeting support

### DIFF
--- a/modules/dasBidAdapter.js
+++ b/modules/dasBidAdapter.js
@@ -298,11 +298,9 @@ function interpretResponse(serverResponse) {
         },
       };
 
-      const bidderVariant = bid.ext?.bidder_variant;
-      if (bidderVariant) {
-        bidResponse.adserverTargeting = {
-          'bidder_variant': bidderVariant
-        };
+      const targeting = bid.ext?.targeting;
+      if (targeting) {
+        bidResponse.adserverTargeting = targeting;
       }
 
       if (bid.mtype === 1) {

--- a/modules/dasBidAdapter.js
+++ b/modules/dasBidAdapter.js
@@ -298,6 +298,13 @@ function interpretResponse(serverResponse) {
         },
       };
 
+      const bidderVariant = bid.ext?.bidder_variant;
+      if (bidderVariant) {
+        bidResponse.adserverTargeting = {
+          'bidder_variant': bidderVariant
+        };
+      }
+
       if (bid.mtype === 1) {
         bidResponse.mediaType = BANNER;
         bidResponse.ad = bid.adm;

--- a/test/spec/modules/dasBidAdapter_spec.js
+++ b/test/spec/modules/dasBidAdapter_spec.js
@@ -338,6 +338,41 @@ describe('dasBidAdapter', function () {
         expect(spec.interpretResponse({ body: { seatbid: [] } })).to.be.an('array').that.is.empty;
       });
 
+      it('should include adserverTargeting with bidder_variant when present in ext', function () {
+        const responseWithVariant = {
+          body: {
+            seatbid: [{
+              bid: [{
+                impid: 'bid123',
+                price: 3.5,
+                w: 300,
+                h: 250,
+                adm: '<creative>',
+                crid: 'crid123',
+                mtype: 1,
+                adomain: ['advertiser.com'],
+                ext: {
+                  bidder_variant: 'variant_a'
+                }
+              }]
+            }],
+            cur: 'USD'
+          }
+        };
+
+        const bidResponses = spec.interpretResponse(responseWithVariant);
+
+        expect(bidResponses[0].adserverTargeting).to.deep.equal({
+          'bidder_variant': 'variant_a'
+        });
+      });
+
+      it('should not include adserverTargeting when bidder_variant is not present', function () {
+        const bidResponses = spec.interpretResponse(serverResponse);
+
+        expect(bidResponses[0].adserverTargeting).to.be.undefined;
+      });
+
       it('should return proper bid response for native', function () {
         const nativeResponse = {
           body: {

--- a/test/spec/modules/dasBidAdapter_spec.js
+++ b/test/spec/modules/dasBidAdapter_spec.js
@@ -338,8 +338,8 @@ describe('dasBidAdapter', function () {
         expect(spec.interpretResponse({ body: { seatbid: [] } })).to.be.an('array').that.is.empty;
       });
 
-      it('should include adserverTargeting with bidder_variant when present in ext', function () {
-        const responseWithVariant = {
+      it('should include adserverTargeting when targeting is present in ext', function () {
+        const responseWithTargeting = {
           body: {
             seatbid: [{
               bid: [{
@@ -352,7 +352,9 @@ describe('dasBidAdapter', function () {
                 mtype: 1,
                 adomain: ['advertiser.com'],
                 ext: {
-                  bidder_variant: 'variant_a'
+                  targeting: {
+                    bidder_variant: 'variant_a'
+                  }
                 }
               }]
             }],
@@ -360,14 +362,47 @@ describe('dasBidAdapter', function () {
           }
         };
 
-        const bidResponses = spec.interpretResponse(responseWithVariant);
+        const bidResponses = spec.interpretResponse(responseWithTargeting);
 
         expect(bidResponses[0].adserverTargeting).to.deep.equal({
           'bidder_variant': 'variant_a'
         });
       });
 
-      it('should not include adserverTargeting when bidder_variant is not present', function () {
+      it('should pass through all targeting keys from server', function () {
+        const responseWithMultipleTargeting = {
+          body: {
+            seatbid: [{
+              bid: [{
+                impid: 'bid123',
+                price: 3.5,
+                w: 300,
+                h: 250,
+                adm: '<creative>',
+                crid: 'crid123',
+                mtype: 1,
+                adomain: ['advertiser.com'],
+                ext: {
+                  targeting: {
+                    bidder_variant: 'variant_a',
+                    custom_key: 'custom_value'
+                  }
+                }
+              }]
+            }],
+            cur: 'USD'
+          }
+        };
+
+        const bidResponses = spec.interpretResponse(responseWithMultipleTargeting);
+
+        expect(bidResponses[0].adserverTargeting).to.deep.equal({
+          'bidder_variant': 'variant_a',
+          'custom_key': 'custom_value'
+        });
+      });
+
+      it('should not include adserverTargeting when targeting is not present', function () {
         const bidResponses = spec.interpretResponse(serverResponse);
 
         expect(bidResponses[0].adserverTargeting).to.be.undefined;


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter
- [x] Updated bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

This change adds support for passing custom targeting key-values from the DAS server response to GAM (Google Ad Manager).

### Changes:
- Extract `targeting` object from `bid.ext.targeting` in the `interpretResponse` function
- Pass the entire `targeting` object as `adserverTargeting` on the bid response
- Added unit tests covering presence, absence, and multiple targeting keys

### How it works:
The DAS server can now control which key-values are sent to GAM without requiring changes to the Prebid.js adapter. When the server returns a `targeting` object in the bid extension, all keys are automatically passed to GAM targeting.

Since these are custom keys (without `hb_` prefix), Prebid.js will aggregate values from **all** DAS bids for each ad unit, not just the winning bid.

### Example bid response from server:
```json
{
  "seatbid": [{
    "bid": [{
      "impid": "bid123",
      "price": 3.5,
      "ext": {
        "targeting": {
          "bidder_variant": "variant_a",
          "custom_key": "custom_value"
        }
      }
    }]
  }]
}