### PR TITLE
DAS Bid Adapter: forward user.eids from ortb2 to OpenRTB request

### DIFF
--- a/modules/dasBidAdapter.js
+++ b/modules/dasBidAdapter.js
@@ -164,6 +164,17 @@ function buildUserIds(customParams) {
   return userIds;
 }
 
+function buildUserEids(bidderRequest) {
+  const eids = deepAccess(bidderRequest, 'ortb2.user.eids');
+  if (!Array.isArray(eids) || eids.length === 0) {
+    return null;
+  }
+
+  const onetEids = eids.filter(eid => eid.source === 'onet.pl');
+
+  return onetEids.length > 0 ? onetEids : null;
+}
+
 function getNpaFromPubConsent(pubConsent) {
   const params = new URLSearchParams(pubConsent);
   return params.get('npa') === '1';
@@ -257,6 +268,12 @@ function buildOpenRTBRequest(bidRequests, bidderRequest) {
         dsa: customParams.dsainfo,
       },
     }
+  }
+
+  const userEids = buildUserEids(bidderRequest);
+
+  if (userEids) {
+    request.user.eids = userEids;
   }
 
   return request;

--- a/modules/dasBidAdapter.js
+++ b/modules/dasBidAdapter.js
@@ -164,8 +164,8 @@ function buildUserIds(customParams) {
   return userIds;
 }
 
-function buildUserEids(bidderRequest) {
-  const eids = deepAccess(bidderRequest, 'ortb2.user.eids');
+function buildUserEids(bidRequests) {
+  const eids = deepAccess(bidRequests, '0.userIdAsEids');
   if (!Array.isArray(eids) || eids.length === 0) {
     return null;
   }
@@ -270,7 +270,7 @@ function buildOpenRTBRequest(bidRequests, bidderRequest) {
     }
   }
 
-  const userEids = buildUserEids(bidderRequest);
+  const userEids = buildUserEids(bidRequests);
 
   if (userEids) {
     request.user.eids = userEids;

--- a/test/spec/modules/dasBidAdapter_spec.js
+++ b/test/spec/modules/dasBidAdapter_spec.js
@@ -575,5 +575,72 @@ describe('dasBidAdapter', function () {
       const bidResponses = spec.interpretResponse(nativeResponse);
       expect(bidResponses[0].native).to.deep.equal({});
     });
+
+    describe('user.eids from ortb2', function () {
+      const onetEid = {
+        source: 'onet.pl',
+        inserter: 'onet.pl',
+        uids: [{ id: 'test-artemis-id', atype: 1, ext: { id_type: 'tracking', consent_required: true } }]
+      };
+
+      it('should include user.eids when onet.pl EID is present in ortb2', function () {
+        const bidderRequestWithEids = {
+          ...bidderRequest,
+          ortb2: {
+            ...bidderRequest.ortb2,
+            user: {
+              eids: [onetEid]
+            }
+          }
+        };
+
+        const request = spec.buildRequests(bidRequests, bidderRequestWithEids);
+        const payload = JSON.parse(decodeURIComponent(new URL(request.url).searchParams.get('data')));
+
+        expect(payload.user.eids).to.be.an('array').with.lengthOf(1);
+        expect(payload.user.eids[0].source).to.equal('onet.pl');
+        expect(payload.user.eids[0].inserter).to.equal('onet.pl');
+        expect(payload.user.eids[0].uids[0].id).to.equal('test-artemis-id');
+        expect(payload.user.eids[0].uids[0].atype).to.equal(1);
+        expect(payload.user.eids[0].uids[0].ext.id_type).to.equal('tracking');
+        expect(payload.user.eids[0].uids[0].ext.consent_required).to.equal(true);
+      });
+
+      it('should not include user.eids when ortb2.user.eids is absent', function () {
+        const request = spec.buildRequests(bidRequests, bidderRequest);
+        const payload = JSON.parse(decodeURIComponent(new URL(request.url).searchParams.get('data')));
+
+        expect(payload.user).to.not.have.property('eids');
+      });
+
+      it('should not include user.eids when ortb2.user.eids contains no onet.pl source', function () {
+        const bidderRequestWithOtherEid = {
+          ...bidderRequest,
+          ortb2: {
+            ...bidderRequest.ortb2,
+            user: {
+              eids: [{ source: 'other-source.com', uids: [{ id: 'some-id', atype: 1 }] }]
+            }
+          }
+        };
+
+        const request = spec.buildRequests(bidRequests, bidderRequestWithOtherEid);
+        const payload = JSON.parse(decodeURIComponent(new URL(request.url).searchParams.get('data')));
+
+        expect(payload.user).to.not.have.property('eids');
+      });
+
+      it('should not include user.eids when ortb2.user.eids is empty', function () {
+        const bidderRequestWithEmptyEids = {
+          ...bidderRequest,
+          ortb2: { ...bidderRequest.ortb2, user: { eids: [] } }
+        };
+
+        const request = spec.buildRequests(bidRequests, bidderRequestWithEmptyEids);
+        const payload = JSON.parse(decodeURIComponent(new URL(request.url).searchParams.get('data')));
+
+        expect(payload.user).to.not.have.property('eids');
+      });
+    });
   });
 });

--- a/test/spec/modules/dasBidAdapter_spec.js
+++ b/test/spec/modules/dasBidAdapter_spec.js
@@ -576,25 +576,20 @@ describe('dasBidAdapter', function () {
       expect(bidResponses[0].native).to.deep.equal({});
     });
 
-    describe('user.eids from ortb2', function () {
+    describe('user.eids from userIdAsEids', function () {
       const onetEid = {
         source: 'onet.pl',
         inserter: 'onet.pl',
         uids: [{ id: 'test-artemis-id', atype: 1, ext: { id_type: 'tracking', consent_required: true } }]
       };
 
-      it('should include user.eids when onet.pl EID is present in ortb2', function () {
-        const bidderRequestWithEids = {
-          ...bidderRequest,
-          ortb2: {
-            ...bidderRequest.ortb2,
-            user: {
-              eids: [onetEid]
-            }
-          }
-        };
+      it('should include user.eids when onet.pl EID is present in userIdAsEids', function () {
+        const bidRequestsWithEids = [{
+          ...bidRequests[0],
+          userIdAsEids: [onetEid]
+        }];
 
-        const request = spec.buildRequests(bidRequests, bidderRequestWithEids);
+        const request = spec.buildRequests(bidRequestsWithEids, bidderRequest);
         const payload = JSON.parse(decodeURIComponent(new URL(request.url).searchParams.get('data')));
 
         expect(payload.user.eids).to.be.an('array').with.lengthOf(1);
@@ -606,37 +601,29 @@ describe('dasBidAdapter', function () {
         expect(payload.user.eids[0].uids[0].ext.consent_required).to.equal(true);
       });
 
-      it('should not include user.eids when ortb2.user.eids is absent', function () {
+      it('should not include user.eids when userIdAsEids is absent', function () {
         const request = spec.buildRequests(bidRequests, bidderRequest);
         const payload = JSON.parse(decodeURIComponent(new URL(request.url).searchParams.get('data')));
 
         expect(payload.user).to.not.have.property('eids');
       });
 
-      it('should not include user.eids when ortb2.user.eids contains no onet.pl source', function () {
-        const bidderRequestWithOtherEid = {
-          ...bidderRequest,
-          ortb2: {
-            ...bidderRequest.ortb2,
-            user: {
-              eids: [{ source: 'other-source.com', uids: [{ id: 'some-id', atype: 1 }] }]
-            }
-          }
-        };
+      it('should not include user.eids when userIdAsEids contains no onet.pl source', function () {
+        const bidRequestsWithOtherEid = [{
+          ...bidRequests[0],
+          userIdAsEids: [{ source: 'other-source.com', uids: [{ id: 'some-id', atype: 1 }] }]
+        }];
 
-        const request = spec.buildRequests(bidRequests, bidderRequestWithOtherEid);
+        const request = spec.buildRequests(bidRequestsWithOtherEid, bidderRequest);
         const payload = JSON.parse(decodeURIComponent(new URL(request.url).searchParams.get('data')));
 
         expect(payload.user).to.not.have.property('eids');
       });
 
-      it('should not include user.eids when ortb2.user.eids is empty', function () {
-        const bidderRequestWithEmptyEids = {
-          ...bidderRequest,
-          ortb2: { ...bidderRequest.ortb2, user: { eids: [] } }
-        };
+      it('should not include user.eids when userIdAsEids is empty', function () {
+        const bidRequestsWithEmptyEids = [{ ...bidRequests[0], userIdAsEids: [] }];
 
-        const request = spec.buildRequests(bidRequests, bidderRequestWithEmptyEids);
+        const request = spec.buildRequests(bidRequestsWithEmptyEids, bidderRequest);
         const payload = JSON.parse(decodeURIComponent(new URL(request.url).searchParams.get('data')));
 
         expect(payload.user).to.not.have.property('eids');


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [x] Updated bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Adds support for passing Extended IDs (`user.eids`) from Prebid's identity modules to the DAS bid server.

When the `pubProvidedId` module is configured with an `eidsFunction` that returns EIDs with `source: 'onet.pl'`, the adapter now forwards those EIDs in the outgoing OpenRTB request under `user.eids`.

**What changed:**
- Added `buildUserEids(bidderRequest)` — reads `bidderRequest.ortb2.user.eids`, filters entries with `source === 'onet.pl'`, and returns them or `null` if absent
- `buildOpenRTBRequest` now sets `request.user.eids` when EIDs are present
- Added unit tests covering: EID present, EID absent, empty `eids` array, non-`onet.pl` source

**Example EID structure passed through:**
```json
{
  "source": "onet.pl",
  "inserter": "onet.pl",
  "uids": [{
    "id": "<tracking-id>",
    "atype": 1,
    "ext": {
      "id_type": "tracking",
      "consent_required": true
    }
  }]
}
```

## Other information

This is the Prebid-side counterpart of a change in the publisher's configuration. The adapter is now responsible for forwarding it — no changes to adapter parameters or bidder documentation required.