### PR TITLE
Feature/adshield

### DIFF
--- a/modules/dasBidAdapter.js
+++ b/modules/dasBidAdapter.js
@@ -147,6 +147,12 @@ function parseParams(params, bidderRequest) {
     customParams.dsainfo = dsaRequired;
   }
 
+  // AdShield anti-adblock recovery signal (set by dlApi as customParams.asd, like adbeta).
+  // Routed into ext.keyvalues so das-bidder serves only adblock_compability == 2 demand.
+  if (customParams.asd !== undefined) {
+    keyValues.asd = customParams.asd;
+  }
+
   return {
     customParams,
     keyValues,
@@ -356,6 +362,10 @@ export const spec = {
     const jsonData = JSON.stringify(data);
     const baseUrl = getEndpoint(data.ext.network);
     const fullUrl = `${baseUrl}?data=${encodeURIComponent(jsonData)}`;
+
+    const queryParams = Object.fromEntries(new URL(fullUrl).searchParams.entries());
+    // eslint-disable-next-line no-console
+    console.log('[das] CSR request:', { url: baseUrl, fullUrl, data: jsonData, queryParams });
 
     // adbeta needs credentials omitted to avoid CORS issues, especially in Firefox
     const useCredentials = !data.ext?.adbeta;

--- a/modules/dasBidAdapter.js
+++ b/modules/dasBidAdapter.js
@@ -147,12 +147,6 @@ function parseParams(params, bidderRequest) {
     customParams.dsainfo = dsaRequired;
   }
 
-  // AdShield anti-adblock recovery signal (set by dlApi as customParams.asd, like adbeta).
-  // Routed into ext.keyvalues so das-bidder serves only adblock_compability == 2 demand.
-  if (customParams.asd !== undefined) {
-    keyValues.asd = customParams.asd;
-  }
-
   return {
     customParams,
     keyValues,
@@ -252,6 +246,13 @@ function buildOpenRTBRequest(bidRequests, bidderRequest) {
 
   if (customParams.adbeta) {
     request.ext.adbeta = customParams.adbeta;
+  }
+
+  // AdShield anti-adblock recovery signal (set by dlApi as customParams.asd, like adbeta).
+  // Sent as a plain ext field (not a key-value) so das-bidder serves only
+  // adblock-compatible demand (adblock_compability == 2).
+  if (customParams.asd) {
+    request.ext.asd = customParams.asd;
   }
 
   if (bidderRequest.device) {
@@ -362,10 +363,6 @@ export const spec = {
     const jsonData = JSON.stringify(data);
     const baseUrl = getEndpoint(data.ext.network);
     const fullUrl = `${baseUrl}?data=${encodeURIComponent(jsonData)}`;
-
-    const queryParams = Object.fromEntries(new URL(fullUrl).searchParams.entries());
-    // eslint-disable-next-line no-console
-    console.log('[das] CSR request:', { url: baseUrl, fullUrl, data: jsonData, queryParams });
 
     // adbeta needs credentials omitted to avoid CORS issues, especially in Firefox
     const useCredentials = !data.ext?.adbeta;

--- a/modules/ringieraxelspringerBidAdapter.js
+++ b/modules/ringieraxelspringerBidAdapter.js
@@ -374,9 +374,13 @@ export const spec = {
       mediaType: (bid.mediaTypes && bid.mediaTypes.banner) ? 'display' : NATIVE
     }));
 
+    const url = getEndpoint(network) + contextQuery + slotsQuery + gdprQuery;
+    // eslint-disable-next-line no-console
+    console.log('[ringieraxelspringer] CSR request:', url);
+
     return [{
       method: 'GET',
-      url: getEndpoint(network) + contextQuery + slotsQuery + gdprQuery,
+      url,
       bidIds: bidIds
     }];
   },

--- a/modules/ringieraxelspringerBidAdapter.js
+++ b/modules/ringieraxelspringerBidAdapter.js
@@ -374,13 +374,9 @@ export const spec = {
       mediaType: (bid.mediaTypes && bid.mediaTypes.banner) ? 'display' : NATIVE
     }));
 
-    const url = getEndpoint(network) + contextQuery + slotsQuery + gdprQuery;
-    // eslint-disable-next-line no-console
-    console.log('[ringieraxelspringer] CSR request:', url);
-
     return [{
       method: 'GET',
-      url,
+      url: getEndpoint(network) + contextQuery + slotsQuery + gdprQuery,
       bidIds: bidIds
     }];
   },

--- a/test/spec/modules/dasBidAdapter_spec.js
+++ b/test/spec/modules/dasBidAdapter_spec.js
@@ -179,6 +179,30 @@ describe('dasBidAdapter', function () {
       expect(payload.imp[0].banner.format[0]).to.deep.equal({ w: 300, h: 250 });
     });
 
+    it('should route customParams.asd into ext.keyvalues for AdShield recovery', function () {
+      const asdBidRequests = [{
+        ...bidRequests[0],
+        params: {
+          ...bidRequests[0].params,
+          customParams: { asd: 1 }
+        }
+      }];
+
+      const request = spec.buildRequests(asdBidRequests, bidderRequest);
+      const params = new URLSearchParams(request.url.split('?')[1]);
+      const payload = JSON.parse(decodeURIComponent(params.get('data')));
+
+      expect(payload.ext.keyvalues.asd).to.equal(1);
+    });
+
+    it('should not set ext.keyvalues.asd without customParams.asd', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const params = new URLSearchParams(request.url.split('?')[1]);
+      const payload = JSON.parse(decodeURIComponent(params.get('data')));
+
+      expect(payload.ext.keyvalues.asd).to.be.undefined;
+    });
+
     it('should use GET method when URL is under 8192 characters', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest);
       expect(request.method).to.equal('GET');

--- a/test/spec/modules/dasBidAdapter_spec.js
+++ b/test/spec/modules/dasBidAdapter_spec.js
@@ -179,7 +179,7 @@ describe('dasBidAdapter', function () {
       expect(payload.imp[0].banner.format[0]).to.deep.equal({ w: 300, h: 250 });
     });
 
-    it('should route customParams.asd into ext.keyvalues for AdShield recovery', function () {
+    it('should route customParams.asd into ext.asd for AdShield recovery', function () {
       const asdBidRequests = [{
         ...bidRequests[0],
         params: {
@@ -192,15 +192,16 @@ describe('dasBidAdapter', function () {
       const params = new URLSearchParams(request.url.split('?')[1]);
       const payload = JSON.parse(decodeURIComponent(params.get('data')));
 
-      expect(payload.ext.keyvalues.asd).to.equal(1);
+      expect(payload.ext.asd).to.equal(1);
+      expect(payload.ext.keyvalues.asd).to.be.undefined;
     });
 
-    it('should not set ext.keyvalues.asd without customParams.asd', function () {
+    it('should not set ext.asd without customParams.asd', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest);
       const params = new URLSearchParams(request.url.split('?')[1]);
       const payload = JSON.parse(decodeURIComponent(params.get('data')));
 
-      expect(payload.ext.keyvalues.asd).to.be.undefined;
+      expect(payload.ext.asd).to.be.undefined;
     });
 
     it('should use GET method when URL is under 8192 characters', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
